### PR TITLE
Add offline cache for downloaded files

### DIFF
--- a/makers/appimage/package.json
+++ b/makers/appimage/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@electron-forge/maker-base": "^6.0.4",
     "@spacingbat3/lss": "^1.0.0",
+    "env-paths": "^2.2.1",
+    "fs-extra": "^10.1.0",
     "node-fetch": "^3.2.5",
     "semver": "^7.3.8"
   },
@@ -32,5 +34,8 @@
   },
   "engines": {
     "node": ">=19.0.0 || ^18.11.0 || ^16.1.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^8.1.2"
   }
 }

--- a/makers/appimage/src/cache.ts
+++ b/makers/appimage/src/cache.ts
@@ -1,0 +1,47 @@
+import envPaths from 'env-paths';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import * as url from 'url';
+import * as crypto from 'crypto';
+
+const defaultCacheRoot = envPaths('reforged', {
+  suffix: '',
+}).cache;
+
+export class Cache {
+  public static getCacheDirectory(downloadUrl: string): string {
+    const parsedDownloadUrl = url.parse(downloadUrl);
+    const { search, hash, pathname, ...rest } = parsedDownloadUrl;
+    const strippedUrl = url.format({ ...rest, pathname: path.dirname(pathname ?? 'reforged') });
+
+    return crypto
+      .createHash('sha256')
+      .update(strippedUrl)
+      .digest('hex');
+  }
+
+  public getCachePath(downloadUrl: string, fileName: string): string {
+    return path.resolve(defaultCacheRoot, Cache.getCacheDirectory(downloadUrl), fileName);
+  }
+
+  public async getPathForFileInCache(url: string, fileName: string): Promise<string | null> {
+    const cachePath = this.getCachePath(url, fileName);
+    if (await fs.pathExists(cachePath)) {
+      return cachePath;
+    }
+
+    return null;
+  }
+
+  public async putFileInCache(url: string, fileName: string, fileBuffer: ArrayBuffer): Promise<string> {
+    const cachePath = this.getCachePath(url, fileName);
+    if (await fs.pathExists(cachePath)) {
+      await fs.remove(cachePath);
+    }
+
+    await fs.ensureDir(path.dirname(cachePath));
+    await fs.writeFile(cachePath, Buffer.from(fileBuffer));
+
+    return cachePath;
+  }
+}

--- a/makers/appimage/tsconfig.json
+++ b/makers/appimage/tsconfig.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "src/main.ts",
+    "src/cache.ts",
     "src/utils.ts"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/node": "^18.11.17",
         "@types/semver": "^7.3.13",
         "typedoc": "^0.24.6",
-        "typescript": "^5.0.2"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": ">=19.0.0 || ^18.11.0 || ^16.1.0",
@@ -41,8 +41,13 @@
       "dependencies": {
         "@electron-forge/maker-base": "^6.0.4",
         "@spacingbat3/lss": "^1.0.0",
+        "env-paths": "^2.2.1",
+        "fs-extra": "^10.1.0",
         "node-fetch": "^3.2.5",
         "semver": "^7.3.8"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "^8.1.2"
       },
       "engines": {
         "node": ">=19.0.0 || ^18.11.0 || ^16.1.0"
@@ -755,6 +760,15 @@
         "@types/keyv": "^3.1.4",
         "@types/node": "*",
         "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/node": "^18.11.17",
     "@types/semver": "^7.3.13",
     "typedoc": "^0.24.6",
-    "typescript": "^5.0.2"
+    "typescript": "^5.1.6"
   },
   "workspaces": [
     "makers/*/",


### PR DESCRIPTION
This allows `@reforged/maker-appimage` to work offline (or online faster) and allows for offline CI with guaranteed reproducible builds.

Highly inspired by `@electron/get`
https://github.com/electron/get/blob/4e0b055a7c8aa337215a8cd20880acc262d5a925/src/Cache.ts
https://github.com/electron/get/blob/4e0b055a7c8aa337215a8cd20880acc262d5a925/src/index.ts#L66C9-L66C9

You can check it by installing from here https://www.npmjs.com/package/@futpib/maker-appimage