### PR TITLE
also check for a string primitive when doing error handling of mkSquashFs

### DIFF
--- a/makers/appimage/src/utils.ts
+++ b/makers/appimage/src/utils.ts
@@ -195,7 +195,7 @@ export function mkSquashFs(...squashfsOptions:string[]) {
       const oDecoder = new TextDecoder(), eDecoder = new TextDecoder();
       let lastProgress = 0, stderrCollector = "";
       mkSquashFS.stderr?.on("data", (chunk:Uint8Array|string) => {
-        if(chunk instanceof String)
+        if(typeof chunk === "string" || chunk instanceof String)
           stderrCollector+=chunk;
         else if(chunk instanceof Object.getPrototypeOf(Int8Array) || chunk instanceof ArrayBuffer || chunk instanceof DataView)
           stderrCollector+=eDecoder.decode(chunk as AllowSharedBufferSource, {stream:true});


### PR DESCRIPTION
Before this fix, I was getting

```
❯ Making a AppImage distributable for linux/x64
@reforged/maker-appimage 22185: Initializing maker metadata.
@reforged/maker-appimage 22185: Setup cleanup hooks for error scenarios.
@reforged/maker-appimage 22185: Queuing asynchronous jobs batches.
@reforged/maker-appimage 22185: Waiting for queued jobs to finish.
@reforged/maker-appimage 22185: Writing '.desktop' file to 'workDir'.
@reforged/maker-appimage 22185: Copying Electron app data.
@reforged/maker-appimage 22185: Fetched AppImage AppRun from mirror.
@reforged/maker-appimage 22185: Writing AppRun to file.
@reforged/maker-appimage 22185: Preparing 'mksquashfs' arguments for data image generation.
@reforged/maker-appimage 22185: Queuing 'mksquashfs' task.

An unhandled exception has occurred inside Forge:
Invalid chunk type String.
TypeError: Invalid chunk type String.
    at Socket.<anonymous> (file:///Users/roccob/dev/ReForged/makers/appimage/dist/utils.js:103:23)
    at Socket.emit (node:events:530:35)
    at Socket.emit (node:domain:488:12)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```