### PR TITLE
chore: Bump Forge to v8

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/SpacingBat3/ReForged.git"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.1.0",
+    "@electron-forge/cli": "^8.0.0-alpha.3",
     "@reforged/maker-appimage": "file:../makers/appimage",
     "@reforged/plugin-launcher": "file:../plugins/launcher",
     "electron": "latest"

--- a/makers/appimage/package.json
+++ b/makers/appimage/package.json
@@ -25,7 +25,7 @@
   "author": "SpacingBat3 <git@spacingbat3.anonaddy.com> (https://github.com/SpacingBat3)",
   "license": "ISC",
   "dependencies": {
-    "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+    "@electron-forge/maker-base": "^6.0.0 || ^7.0.0 || ^8.0.0-alpha.3",
     "@reforged/maker-types": "^2.1.0",
     "@spacingbat3/lss": "^1.0.0",
     "semver": "^7.3.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       "version": "5.2.0",
       "license": "ISC",
       "dependencies": {
-        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0",
+        "@electron-forge/maker-base": "^6.0.0 || ^7.0.0 || ^8.0.0-alpha.3",
         "@reforged/maker-types": "^2.1.0",
         "@spacingbat3/lss": "^1.0.0",
         "semver": "^7.3.8"
@@ -57,6 +57,47 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
+      }
+    },
+    "makers/appimage/node_modules/@electron-forge/maker-base": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-OA/tluXLBIGVZ4PIP5Y5em5wr/YWfO2hobdyrG4XeDje900/aED7tp5g2PiSxIFZTECe0ZIz4V7vC6V4eDV25Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "fs-extra": "^10.0.0",
+        "which": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "makers/appimage/node_modules/@electron-forge/shared-types": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-tspB4fmHuOA+CGbfc55SaU0+kQd580lpVRatB7/f7IlN58ZAQ9ZV6KtO7b7I9nFciRIv73MNpCQkG3z++fJZ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "8.0.0-alpha.3",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "makers/appimage/node_modules/@electron-forge/tracer": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-g2+RiMG8Nrx37FY/QItUmRK209EErvhdy3Eo+gEN964LeCeuVWMfsodp+Vh9DdqHhoVeIvlBgMn1NKGV3YlK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6880,7 +6880,46 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@electron-forge/plugin-base": "^7.8.3"
+        "@electron-forge/plugin-base": "^8.0.0-alpha.3"
+      }
+    },
+    "plugins/launcher/node_modules/@electron-forge/plugin-base": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-hCB/XtpiCxI/UKw29qH3f8wvvWpbdD+AhYFf2cRwUrVQQ6jzV+mtuRcGTqCu8C07hXi6xXIsWE2JJjtimSxGRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/shared-types": "8.0.0-alpha.3"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "plugins/launcher/node_modules/@electron-forge/shared-types": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-tspB4fmHuOA+CGbfc55SaU0+kQd580lpVRatB7/f7IlN58ZAQ9ZV6KtO7b7I9nFciRIv73MNpCQkG3z++fJZ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/tracer": "8.0.0-alpha.3",
+        "@electron/packager": "^18.3.5",
+        "@electron/rebuild": "^3.7.0",
+        "listr2": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      }
+    },
+    "plugins/launcher/node_modules/@electron-forge/tracer": {
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-g2+RiMG8Nrx37FY/QItUmRK209EErvhdy3Eo+gEN964LeCeuVWMfsodp+Vh9DdqHhoVeIvlBgMn1NKGV3YlK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chrome-trace-event": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 14.17.5"
       }
     },
     "shared/maker-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "version": "1.0.0",
       "license": "UNLICENSE",
       "devDependencies": {
-        "@electron-forge/cli": "^7.1.0",
+        "@electron-forge/cli": "^8.0.0-alpha.3",
         "@reforged/maker-appimage": "file:../makers/appimage",
         "@reforged/plugin-launcher": "file:../plugins/launcher",
         "electron": "latest"
@@ -59,47 +59,6 @@
         "url": "https://github.com/SpacingBat3/ReForged?sponsor=1"
       }
     },
-    "makers/appimage/node_modules/@electron-forge/maker-base": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-OA/tluXLBIGVZ4PIP5Y5em5wr/YWfO2hobdyrG4XeDje900/aED7tp5g2PiSxIFZTECe0ZIz4V7vC6V4eDV25Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/shared-types": "8.0.0-alpha.3",
-        "fs-extra": "^10.0.0",
-        "which": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "makers/appimage/node_modules/@electron-forge/shared-types": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-tspB4fmHuOA+CGbfc55SaU0+kQd580lpVRatB7/f7IlN58ZAQ9ZV6KtO7b7I9nFciRIv73MNpCQkG3z++fJZ4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/tracer": "8.0.0-alpha.3",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "makers/appimage/node_modules/@electron-forge/tracer": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-g2+RiMG8Nrx37FY/QItUmRK209EErvhdy3Eo+gEN964LeCeuVWMfsodp+Vh9DdqHhoVeIvlBgMn1NKGV3YlK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
-      }
-    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -111,9 +70,9 @@
       }
     },
     "node_modules/@electron-forge/cli": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.11.1.tgz",
-      "integrity": "sha512-pk8AoLsr7t7LBAt0cFD06XFA6uxtPdvtLx06xeal7O9o7GHGCbj29WGwFoJ8Br/ENM0Ho868S3PrAn1PtBXt5g==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-s8R+y7URzxefmk7ga01Gr68ktZ/JrjvLw2X1PA4VewW2ayC8DcBkBU+8ge+/PHSXfWd7xlu8rQgUsmcOgbCLqQ==",
       "dev": true,
       "funding": [
         {
@@ -127,9 +86,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core": "7.11.1",
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core": "8.0.0-alpha.3",
+        "@electron-forge/core-utils": "8.0.0-alpha.3",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
         "@electron/get": "^3.0.0",
         "@inquirer/prompts": "^6.0.1",
         "@listr2/prompt-adapter-inquirer": "^2.0.22",
@@ -151,9 +110,9 @@
       }
     },
     "node_modules/@electron-forge/core": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.11.1.tgz",
-      "integrity": "sha512-YtuPLzggPKPabFAD2rOZFE0s7f4KaUTpGRduhSMbZUqpqD1TIPyfoDBpYiZvao3Ht8pyZeOJjbzcC0LpFs9gIQ==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-DrOMw9bEBfQ4zdx7/k1/XDOtS6XRgofGlpRZlmZw0v6PQQ6S82SDU0VtcFkd7m3owRxDP7Q0fOILBmSMn9i8Iw==",
       "dev": true,
       "funding": [
         {
@@ -167,17 +126,17 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/plugin-base": "7.11.1",
-        "@electron-forge/publisher-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
-        "@electron-forge/template-vite": "7.11.1",
-        "@electron-forge/template-vite-typescript": "7.11.1",
-        "@electron-forge/template-webpack": "7.11.1",
-        "@electron-forge/template-webpack-typescript": "7.11.1",
-        "@electron-forge/tracer": "7.11.1",
+        "@electron-forge/core-utils": "8.0.0-alpha.3",
+        "@electron-forge/maker-base": "8.0.0-alpha.3",
+        "@electron-forge/plugin-base": "8.0.0-alpha.3",
+        "@electron-forge/publisher-base": "8.0.0-alpha.3",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "@electron-forge/template-base": "8.0.0-alpha.3",
+        "@electron-forge/template-vite": "8.0.0-alpha.3",
+        "@electron-forge/template-vite-typescript": "8.0.0-alpha.3",
+        "@electron-forge/template-webpack": "8.0.0-alpha.3",
+        "@electron-forge/template-webpack-typescript": "8.0.0-alpha.3",
+        "@electron-forge/tracer": "8.0.0-alpha.3",
         "@electron/get": "^3.0.0",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
@@ -189,7 +148,6 @@
         "filenamify": "^4.1.0",
         "find-up": "^5.0.0",
         "fs-extra": "^10.0.0",
-        "global-dirs": "^3.0.0",
         "got": "^11.8.5",
         "interpret": "^3.1.1",
         "jiti": "^2.4.2",
@@ -207,13 +165,13 @@
       }
     },
     "node_modules/@electron-forge/core-utils": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.11.1.tgz",
-      "integrity": "sha512-9UxRWVsfcziBsbAA2MS0Oz4yYovQCO2BhnGIfsbKNTBtMc/RcVSxAS0NMyymce44i43p1ZC/FqWhnt1XqYw3bQ==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-+Fr+uKCVNtM58IT10ypfw6WDPAqCK7JO05gTMydhyuVbAb1PTbZyCG3Y11LLhCWLnqvbqACy7PtVeDi8EBj0tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
         "@electron/rebuild": "^3.7.0",
         "@malept/cross-spawn-promise": "^2.0.0",
         "chalk": "^4.0.0",
@@ -229,12 +187,12 @@
       }
     },
     "node_modules/@electron-forge/maker-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.11.1.tgz",
-      "integrity": "sha512-yhZrCGoN6bDeiB5DHFaueZ1h84AReElEj+f0hl2Ph4UbZnO0cnLpbx+Bs+XfMLAiA+beC8muB5UDK5ysfuT9BQ==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-OA/tluXLBIGVZ4PIP5Y5em5wr/YWfO2hobdyrG4XeDje900/aED7tp5g2PiSxIFZTECe0ZIz4V7vC6V4eDV25Q==",
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
         "fs-extra": "^10.0.0",
         "which": "^2.0.2"
       },
@@ -243,37 +201,37 @@
       }
     },
     "node_modules/@electron-forge/plugin-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.11.1.tgz",
-      "integrity": "sha512-lKpSOV1GA3FoYiD9k05i6v4KaQVmojnRgCr7d6VL1bFp13QOtXSaAWhFI9mtSY7rGElOacX6Zt7P7rPoB8T9eQ==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-hCB/XtpiCxI/UKw29qH3f8wvvWpbdD+AhYFf2cRwUrVQQ6jzV+mtuRcGTqCu8C07hXi6xXIsWE2JJjtimSxGRg==",
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/shared-types": "8.0.0-alpha.3"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/publisher-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.11.1.tgz",
-      "integrity": "sha512-rXE9oMFGMtdQrixnumWYH5TTGsp99iPHZb3jI74YWq518ctCh6DlIgWlhf6ok2X0+lhWovcIb45KJucUFAQ13w==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-hmvVGtg1s/43tVKh7qHkS1XBp09CvsC8+e2KBt+3TKOtf20bIDbEC9yd5cIrxV5iNL/CO2XOyjJsFptlYzlfnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1"
+        "@electron-forge/shared-types": "8.0.0-alpha.3"
       },
       "engines": {
         "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/shared-types": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.11.1.tgz",
-      "integrity": "sha512-vvBWdAEh53UJlDGUevpaJk1+sqDMQibfrbHR+0IPA4MPyQex7/Uhv3vYH9oGHujBVAChQahjAuJt0fG6IJBLZg==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-tspB4fmHuOA+CGbfc55SaU0+kQd580lpVRatB7/f7IlN58ZAQ9ZV6KtO7b7I9nFciRIv73MNpCQkG3z++fJZ4Q==",
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/tracer": "7.11.1",
+        "@electron-forge/tracer": "8.0.0-alpha.3",
         "@electron/packager": "^18.3.5",
         "@electron/rebuild": "^3.7.0",
         "listr2": "^7.0.2"
@@ -283,14 +241,14 @@
       }
     },
     "node_modules/@electron-forge/template-base": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.11.1.tgz",
-      "integrity": "sha512-XpTaEf+EfQw+0BlSAtSpZKYIKYvKu4raNzSGHZZoSYHp+HDC7R+MlpFQmSJiGdYQzQ14C+uxO42tVjgM0DMbpw==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-FUcqFB2axWkBgAql1aNnHiluTymqiUNsjKEurjYqCA/UJVayYW0TJ+8gDJuKK05JmcJesR/LcrLSByG95XL2+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/core-utils": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
+        "@electron-forge/core-utils": "8.0.0-alpha.3",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.3.1",
         "fs-extra": "^10.0.0",
@@ -302,14 +260,14 @@
       }
     },
     "node_modules/@electron-forge/template-vite": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.11.1.tgz",
-      "integrity": "sha512-Or8Lxf4awoeUZoMTKJEw5KQDIhqOFs24WhVka3yZXxc6VgVWN79KmYKYM6uM/YMQttmafhsBhY2t1Lxo1WR/ug==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-fOH1PVAhFNRfBlgoj8q31KOtYpgYyDK5khQcMIXjE2K3HyObGcRtvnb/uKOq3i2ogqAO91mjw0tT/fMqo8zksQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "@electron-forge/template-base": "8.0.0-alpha.3",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -317,14 +275,14 @@
       }
     },
     "node_modules/@electron-forge/template-vite-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.11.1.tgz",
-      "integrity": "sha512-Us4AHXFb+4z+gXgZImSqMBS63oKnsQWLOhqRg321xiDzu2UcQPlwgWNb4rAEKNVC1e7LXrUNDHuBiTrQkvWXbg==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-9nfxLYLWP0kda7IW3EB094Um0LSQZSmsUgWsoPiQixPHsGCU2yZOHuQahHNrChWQEs/2HUJvhE0gJp29B+yUiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "@electron-forge/template-base": "8.0.0-alpha.3",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -332,14 +290,14 @@
       }
     },
     "node_modules/@electron-forge/template-webpack": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.11.1.tgz",
-      "integrity": "sha512-15lbXxi+er461MPk6sbwAOyjofAHwmQjTvxNCiNpaU2naEwbj3t0SlLq/BMr5HxnVOaMmA7+lKV9afkIom+d4Q==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-aDiRbwm1QOtOJhmCrSnpNmL42gEZFEL3zdKQOLd1bl8r+D+oeIx6Y0rpUzbseVS/vrLdHiOj6QXYHwlRyjQEhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "@electron-forge/template-base": "8.0.0-alpha.3",
         "fs-extra": "^10.0.0"
       },
       "engines": {
@@ -347,14 +305,14 @@
       }
     },
     "node_modules/@electron-forge/template-webpack-typescript": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.11.1.tgz",
-      "integrity": "sha512-6ExfFnFkHBz8rvRFTFg5HVGTC12uJpbVk4q8DVg0R8rhhxhqiVNh8lF2UPtZ2yT2UtGWjXNVlyP3Y3T6q6E3GQ==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-6PqfBKGnLL7PdZOPcacILYk4xQgrKV6Y9NtYCe34P68cbt2aq+UT89KfuKGVFTCZzBc5ohwG/DOB4/dslpTBKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron-forge/shared-types": "7.11.1",
-        "@electron-forge/template-base": "7.11.1",
+        "@electron-forge/shared-types": "8.0.0-alpha.3",
+        "@electron-forge/template-base": "8.0.0-alpha.3",
         "fs-extra": "^10.0.0",
         "typescript": "~5.4.5",
         "webpack": "^5.69.1"
@@ -378,9 +336,9 @@
       }
     },
     "node_modules/@electron-forge/tracer": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.11.1.tgz",
-      "integrity": "sha512-tiB6cglVQFcSw9N8GRwVwZUeB9u0DOx2Mj7aFXBUsFLUYQapvVGv51tUSy/UAW5lvmubGscYIILuVko+II3+NA==",
+      "version": "8.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-8.0.0-alpha.3.tgz",
+      "integrity": "sha512-g2+RiMG8Nrx37FY/QItUmRK209EErvhdy3Eo+gEN964LeCeuVWMfsodp+Vh9DdqHhoVeIvlBgMn1NKGV3YlK3Q==",
       "license": "MIT",
       "dependencies": {
         "chrome-trace-event": "^1.0.3"
@@ -3557,22 +3515,6 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/global-dirs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
-      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ini": "2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -3809,16 +3751,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/interpret": {
       "version": "3.1.1",
@@ -6881,45 +6813,6 @@
       "license": "ISC",
       "dependencies": {
         "@electron-forge/plugin-base": "^8.0.0-alpha.3"
-      }
-    },
-    "plugins/launcher/node_modules/@electron-forge/plugin-base": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-hCB/XtpiCxI/UKw29qH3f8wvvWpbdD+AhYFf2cRwUrVQQ6jzV+mtuRcGTqCu8C07hXi6xXIsWE2JJjtimSxGRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/shared-types": "8.0.0-alpha.3"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "plugins/launcher/node_modules/@electron-forge/shared-types": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-tspB4fmHuOA+CGbfc55SaU0+kQd580lpVRatB7/f7IlN58ZAQ9ZV6KtO7b7I9nFciRIv73MNpCQkG3z++fJZ4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/tracer": "8.0.0-alpha.3",
-        "@electron/packager": "^18.3.5",
-        "@electron/rebuild": "^3.7.0",
-        "listr2": "^7.0.2"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      }
-    },
-    "plugins/launcher/node_modules/@electron-forge/tracer": {
-      "version": "8.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-8.0.0-alpha.3.tgz",
-      "integrity": "sha512-g2+RiMG8Nrx37FY/QItUmRK209EErvhdy3Eo+gEN964LeCeuVWMfsodp+Vh9DdqHhoVeIvlBgMn1NKGV3YlK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "chrome-trace-event": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 14.17.5"
       }
     },
     "shared/maker-types": {

--- a/plugins/launcher/package.json
+++ b/plugins/launcher/package.json
@@ -30,6 +30,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@electron-forge/plugin-base": "^7.8.3"
+    "@electron-forge/plugin-base": "^8.0.0-alpha.3"
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> The current patchset is for testing purposes only and will most likely be fully rebased once Electron Forge v8.0.0 will be released. Please bear that in mind this means a like-hood of doing a force push (this branch, not `master`)!
> For that reason, this PR will remain draft until everything will be in-place to work on releasing it.

This patchset aims to bump Forge to v8 and eventually fix any major breakages on the way.

## Current TODO:

- [X] Confirm tests pass for supported Node environments and stable components (currently `maker-appimage` only), both remotely and locally.
- [ ] Confirm if everything works in practice locally (via `example`), additionaly validating initial development stage components (`plugin-launcher`).
- [ ] Confirm everything stays backwards-compatible (it'll probably stay if there are no code changes neccesary) and plan strategy for backwards-incompatible API.

## Related

Upstream issue ticket: https://github.com/electron/forge/issues/4082